### PR TITLE
Version 1.1.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,12 +34,15 @@ test:
     - pip check
 
 about:
-  home: http://sphinx-doc.org/
+  home: https://www.sphinx-doc.org/
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
   summary: sphinxcontrib-serializinghtml is a sphinx extension which outputs "serialized" HTML files (json and pickle).
   dev_url: https://github.com/sphinx-doc/sphinxcontrib-serializinghtml
+  doc_url: https://www.sphinx-doc.org/
+  description: |
+    sphinxcontrib-serializinghtml is a sphinx extension which outputs "serialized" HTML files (json and pickle).
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,10 +28,8 @@ test:
     - sphinxcontrib.serializinghtml
   requires:
     - pip
-    - pytest
   commands:
     - pip check
-    - pytest --pyargs sphinxcontrib.serializinghtml -v
 
 about:
   home: https://www.sphinx-doc.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
     - pip
   commands:
     - pip check
+    - pytest --pyargs sphinxcontrib.serializinghtml -v
 
 about:
   home: https://www.sphinx-doc.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,7 @@ test:
     - sphinxcontrib.serializinghtml
   requires:
     - pip
-    # This is a circular dependency b/c sphinx depends on this package now :-/
-    - sphinx
   commands:
-    # pip check incorrectly shows dependencies for sphinx 4.0.1
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ test:
     - sphinxcontrib.serializinghtml
   requires:
     - pip
+    - pytest
   commands:
     - pip check
     - pytest --pyargs sphinxcontrib.serializinghtml -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
     - flit-core
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.1.5" %}
+{% set version = "1.1.9" %}
 
 package:
   name: sphinxcontrib-serializinghtml
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/sphinxcontrib-serializinghtml/sphinxcontrib-serializinghtml-{{ version }}.tar.gz
-  sha256: aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952
+  url: https://pypi.io/packages/source/s/sphinxcontrib-serializinghtml/sphinxcontrib_serializinghtml-{{ version }}.tar.gz
+  sha256: 0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,22 +15,26 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - setuptools
+    - wheel
+    - flit-core
   run:
-    - python >=3.5
+    - python
+    - sphinx >=5
 
 test:
+  imports:
+    - sphinxcontrib
+    - sphinxcontrib.serializinghtml
   requires:
     - pip
     # This is a circular dependency b/c sphinx depends on this package now :-/
     - sphinx
   commands:
     # pip check incorrectly shows dependencies for sphinx 4.0.1
-    #- pip check
-  imports:
-    - sphinxcontrib
-    - sphinxcontrib.serializinghtml
+    - pip check
 
 about:
   home: http://sphinx-doc.org/


### PR DESCRIPTION
sphinxcontrib-serializinghtml 1.1.9

**Destination channel:** defaults

### Links

- [PKG-3747](https://anaconda.atlassian.net/browse/PKG-3747) 
- [Upstream repository](https://github.com/sphinx-doc/sphinxcontrib-serializinghtml)
- [Upstream changelog/diff](https://github.com/sphinx-doc/sphinxcontrib-serializinghtml/blob/master/CHANGES)
- Relevant dependency PRs: [PKG-3133](https://anaconda.atlassian.net/browse/PKG-3133)

### Explanation of changes:

- bump version to 1.1.9
- remove noarch build
- re-add pip check 
- cleanup and linter fixes


[PKG-3747]: https://anaconda.atlassian.net/browse/PKG-3747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-3133]: https://anaconda.atlassian.net/browse/PKG-3133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ