### PR TITLE
sphinxcontrib-serializinghtml 2.0.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - flit-core >=3.7
   run:
     - python >=3.9
+    - sphinx >=5
 
 test:
   imports:
@@ -30,7 +31,7 @@ test:
   requires:
     - pip
     - pytest
-    - sphinx >=5
+    - defusedxml
   commands:
     - pip check
     - pytest -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - flit-core >=3.7
   run:
-    - python 3.9
+    - python >=3.9
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.10" %}
+{% set version = "2.0.0" %}
 
 package:
   name: sphinxcontrib-serializinghtml
@@ -6,20 +6,20 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/sphinxcontrib-serializinghtml/sphinxcontrib_serializinghtml-{{ version }}.tar.gz
-  sha256: 93f3f5dc458b91b192fe10c397e324f262cf163d79f3282c158e8436a2c4511f
+  sha256: e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
 
 build:
   number: 0
-  skip: True  # [py<39]
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
-    - python
+    - python >=3.9
     - pip
     - flit-core >=3.7
   run:
-    - python
+    - python >=3.9
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
     - pip
     - pytest
     - defusedxml
+    - sphinx >=5
   commands:
     - pip check
     - pytest -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python 3.9
     - pip
     - flit-core >=3.7
   run:
-    - python >=3.9
-    - sphinx >=5
+    - python 3.9
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   home: https://www.sphinx-doc.org/
   license: BSD-2-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENCE.rst
   summary: sphinxcontrib-serializinghtml is a sphinx extension which outputs "serialized" HTML files (json and pickle).
   description: |
     sphinxcontrib-serializinghtml is a sphinx extension which outputs "serialized" HTML files (json and pickle).


### PR DESCRIPTION
sphinxcontrib-serializinghtml 2.0.0 

**Destination channel:** Defaults

### Links

- [PKG-7874]
- dev_url:        https://github.com/sphinx-doc/sphinxcontrib-serializinghtml/tree/2.0.0
- conda_forge:    https://github.com/conda-forge/sphinxcontrib-serializinghtml-feedstock
- pypi:           https://pypi.org/project/sphinxcontrib-serializinghtml/2.0.0
- pypi inspector: https://inspector.pypi.io/project/sphinxcontrib-serializinghtml/2.0.0
- Required for:
    - https://github.com/AnacondaRecipes/sphinx-feedstock/pull/18

### Explanation of changes:

- new version number
- keeping noarch due to test circular dependencies with sphinx


[PKG-7874]: https://anaconda.atlassian.net/browse/PKG-7874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ